### PR TITLE
fix: avoid impl-defined narrowing conversions between size_t and int

### DIFF
--- a/src/ncl_string.c
+++ b/src/ncl_string.c
@@ -71,7 +71,7 @@ char* strToUpper(const char* str) {
 }
 
 int strIndexOf(const char* str, const char c) {
-	for (size_t i = 0; i < strlen(str); i++) {
+	for (int i = 0; i < strlen(str); i++) {
 		if (str[i] == c) {
 			return i;
 		}
@@ -81,7 +81,7 @@ int strIndexOf(const char* str, const char c) {
 }
 
 int strLastIndexOf(const char* str, const char c) {
-	for (size_t i = strlen(str); i > 0; i--) {
+	for (int i = strlen(str); i > 0; i--) {
 		if (str[i] == c) {
 			return i;
 		}


### PR DESCRIPTION
Conversion between `size_t` and `int` is implementation-defined.

Since `strIndexOf` and `strLastIndexOf` must return a signed integer to return an error value of `-1`, use `int` to prevent these implicit narrowing conversions